### PR TITLE
fix: TextInput resetting value even on clicking backspace

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -45,7 +45,13 @@ export const TextField: React.FunctionComponent<Props> = ({
   // updates local to reflect changes
   useEffect(() => {
     checkErrors(Number(parentValue));
-    setValue(Number(parentValue));
+
+    if (
+      value.toString() !== "" &&
+      parentValue.toString() !== value.toString()
+    ) {
+      setValue(parentValue);
+    }
   }, [inputProps]);
 
   // sets error boolean based on error text


### PR DESCRIPTION
when clicking backspace twice in quick succession the value in input field does not set correctly

```
value: 88
<- <-
value: 8 (incorrect)
<-
value:
```

creating a need to click backspace again